### PR TITLE
fix build against nix >= 2.28

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {}
 , system ? builtins.currentSystem
 , pythonPackages ? pkgs.python3Packages
+, nixComponents ? pkgs.nixVersions.nixComponents_2_29
 , forTest ? true
 , forDev ? true
 }:
@@ -9,19 +10,15 @@
     name = "nix-heuristic-gc-env";
 
     NIX_SYSTEM = system;
-    NIX_CFLAGS_COMPILE = [
-      # due to references to top-level headers in sub-dir
-      # https://github.com/NixOS/nix/blob/12bb8cdd381156456a712e4a5a8af3b6bc852eab/src/libutil/signature/signer.hh#L3
-      "-I${pkgs.lib.getDev pkgs.nix}/include/nix"
-    ];
 
     buildInputs = [
       pythonPackages.humanfriendly
       pythonPackages.pybind11
       pythonPackages.setuptools
       pythonPackages.rustworkx
+      nixComponents.nix-store
+      nixComponents.nix-main
       pkgs.boost
-      pkgs.nix
     ] ++ pkgs.lib.optionals forTest [
       pythonPackages.pytest
     ] ++ pkgs.lib.optionals forDev [
@@ -40,15 +37,11 @@
     format = "setuptools";
 
     NIX_SYSTEM = system;
-    NIX_CFLAGS_COMPILE = [
-      # due to references to top-level headers in sub-dir
-      # https://github.com/NixOS/nix/blob/12bb8cdd381156456a712e4a5a8af3b6bc852eab/src/libutil/signature/signer.hh#L3
-      "-I${pkgs.lib.getDev pkgs.nix}/include/nix"
-    ];
 
     buildInputs = [
       pkgs.boost
-      pkgs.nix
+      nixComponents.nix-store
+      nixComponents.nix-main
       pythonPackages.pybind11
       pythonPackages.setuptools
     ];

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "nix-heuristic-gc";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 
 #define _STRINGIFY_MACRO(x) #x
 #define SYSTEM _STRINGIFY_MACRO(NIX_SYSTEM)
+
+#ifdef NIX_LT_2_28
 #include <nix/callback.hh>
 #include <nix/gc-store.hh>
 #include <nix/shared.hh>
@@ -13,6 +15,19 @@
 #include <nix/realisation.hh>
 #include <nix/local-store.hh>
 #include <nix/local-fs-store.hh>
+#else /* ndef NIX_LT_2_28 */
+#include <nix/util/callback.hh>
+#include <nix/store/gc-store.hh>
+#include <nix/main/shared.hh>
+#include <nix/store/store-cast.hh>
+#include <nix/store/store-api.hh>
+#include <nix/store/remote-store.hh>
+#include <nix/store/realisation.hh>
+#include <nix/store/local-store.hh>
+#include <nix/store/local-fs-store.hh>
+#include <nix/store/store-open.hh>
+#endif /* ndef NIX_LT_2_28 */
+
 #undef SYSTEM
 
 #define STRINGIFY(x) #x


### PR DESCRIPTION
Based on #8, but using preprocessor to retain support for nix versions < 2.28. For now at least.

Also omit `flake.lock` because I'll never bother to update that.

cc @Mic92 